### PR TITLE
add `getPromise` call to access removed `then` method of Deferred

### DIFF
--- a/plugins/Relay/installRelayHook.js
+++ b/plugins/Relay/installRelayHook.js
@@ -75,7 +75,7 @@ function installRelayHook(window: Object) {
     requestNumber: number,
   ) {
     var id = Math.random().toString(16).substr(2);
-    request.then(
+    request.getPromise().then(
       response => {
         emit('relay:success', {
           id: id,


### PR DESCRIPTION
The `then` method of `Deferred` was removed (see D9308668 internally) -- the `RelayMutationRequest` (extending `Deferred`) `request` now must call `getPromise()` to access the underlying Promise methods

note that this change to fbjs/Deferred has not yet been synced to Github, so this only occurs internally -- was reported in T33316897